### PR TITLE
Add opensubs query

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "express-async-handler": "^1.1.4",
     "helmet": "^3.21.1",
     "mongoose": "^5.7.5",
-    "opensubtitles-api": "https://github.com/SubJunk/opensubtitles-api/#RemoteFiles"
+    "opensubtitles-api": "https://github.com/js-kyle/opensubtitles-api/#RemoteFiles"
   },
   "devDependencies": {
     "@types/express": "^4.17.1",
@@ -28,7 +28,7 @@
     "@types/mongoose": "^5.5.22",
     "@types/node": "^12.7.12",
     "jest": "^24.9.0",
-    "mongodb-memory-server": "^5.2.8",
+    "mongodb-memory-server-core": "^6.0.1",
     "nodemon": "^1.19.3",
     "typescript": "^3.6.4"
   }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "express": "^4.17.1",
     "express-async-handler": "^1.1.4",
     "helmet": "^3.21.1",
-    "mongoose": "^5.7.5"
+    "mongoose": "^5.7.5",
+    "opensubtitles-api": "https://github.com/SubJunk/opensubtitles-api/#RemoteFiles"
   },
   "devDependencies": {
     "@types/express": "^4.17.1",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "express-async-handler": "^1.1.4",
     "helmet": "^3.21.1",
     "mongoose": "^5.7.5",
-    "opensubtitles-api": "https://github.com/js-kyle/opensubtitles-api/#RemoteFiles"
+    "opensubtitles-api": "https://github.com/js-kyle/opensubtitles-api#RemoteFiles"
   },
   "devDependencies": {
     "@types/express": "^4.17.1",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@types/mongoose": "^5.5.22",
     "@types/node": "^12.7.12",
     "jest": "^24.9.0",
-    "mongodb-memory-server-core": "^6.0.1",
+    "mongodb-memory-server": "^6.0.1",
     "nodemon": "^1.19.3",
     "typescript": "^3.6.4"
   }

--- a/src/app.ts
+++ b/src/app.ts
@@ -36,9 +36,13 @@ app.use((req: Request, res: Response, next: NextFunction) => {
 // error handler
 app.use((err: CustomError, req: Request, res: Response, next: NextFunction) => {
   // set locals, only providing error in development
+  const isDev = req.app.get('env') === 'development';
   res.locals.message = err.message;
-  res.locals.error = req.app.get('env') === 'development' ? err : {};
+  res.locals.error = isDev ? err : {};
   res.status(err.status || 500);
+  if (isDev) {
+    console.error(err);
+  }
   res.send();
 });
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -36,7 +36,7 @@ app.use((req: Request, res: Response, next: NextFunction) => {
 // error handler
 app.use((err: CustomError, req: Request, res: Response, next: NextFunction) => {
   // set locals, only providing error in development
-  const isDev = req.app.get('env') === 'development';
+  const isDev = ['development', 'test'].includes(req.app.get('env'));
   res.locals.message = err.message;
   res.locals.error = isDev ? err : {};
   res.status(err.status || 500);

--- a/src/interfaces.d.ts
+++ b/src/interfaces.d.ts
@@ -1,3 +1,32 @@
 interface CustomError extends Error {
   status?: number;
 }
+
+interface OpensubtitlesIdentifyResponse {
+  subcount: string;
+  added: boolean;
+  metadata: {
+    imdbid: string;
+    title: string;
+    year: string;
+    cast: {
+      [key:string]: string;
+    },
+    country: [string],
+    cover: string;
+    directors: object;
+    duration: string;
+    genres: [string];
+    rating: string;
+    trivia: string;
+    goofs: string;
+    votes: string;
+    language: [string],
+    aka: [string],
+    awards: [string],
+    tagline: string;
+  },
+  moviehash: string;
+  moviebytesize: number;
+  type: string;
+}

--- a/src/routes/media.ts
+++ b/src/routes/media.ts
@@ -3,7 +3,7 @@ import { Request, Response, NextFunction } from 'express';
 import * as MediaController from '../controllers/media';
 const router = express.Router();
 
-router.get('/:osdbhash', function(req: Request, res: Response, next: NextFunction) {
+router.get('/:osdbhash/:filebytesize', function(req: Request, res: Response, next: NextFunction) {
   MediaController.getByOsdbHash(req, res, next);
 });
 

--- a/src/services/opensubtitles.ts
+++ b/src/services/opensubtitles.ts
@@ -1,0 +1,4 @@
+import * as OpenSubtitles from 'opensubtitles-api';
+const osAPI = new OpenSubtitles(process.env.OS_API_USERAGENT || 'TemporaryUserAgent');
+
+export default osAPI;

--- a/test/e2e/media.spec.ts
+++ b/test/e2e/media.spec.ts
@@ -3,7 +3,7 @@ import MediaMetadataModel from '../../src/models/MediaMetadata';
 import * as mongoose from 'mongoose';
 import axios from 'axios';
 
-import { MongoMemoryServer } from 'mongodb-memory-server-core';
+import { MongoMemoryServer } from 'mongodb-memory-server';
 const mongod = new MongoMemoryServer();
 
 const mediaMetaData = { title: 'Interstellar', genres: ['Adventure', 'Drama', 'Sci-Fi'], osdbHash: 'f4245d9379d31e33' };

--- a/test/e2e/media.spec.ts
+++ b/test/e2e/media.spec.ts
@@ -24,12 +24,7 @@ describe('Media Metadata endpoints', () => {
     await mongoose.disconnect();
   });
 
-  it('should return 204 when osdb hash not found', async() => {
-    const res = await axios(`${appUrl}/api/media/xxFAKEHASHxxXXXx`);
-    expect(res.status).toBe(204);
-  });
-
-  it('should return a valid response for existng media record with osdb hash', async() => {
+  it('should return a valid response for existing media record with osdb hash', async() => {
     const res = await axios(`${appUrl}/api/media/8e245d9679d31e12`);
     expect(res.status).toBe(200);
     expect(res.data).toHaveProperty('_id');

--- a/test/e2e/media.spec.ts
+++ b/test/e2e/media.spec.ts
@@ -25,7 +25,7 @@ describe('Media Metadata endpoints', () => {
   });
 
   it('should return a valid response for existing media record with osdb hash', async() => {
-    const res = await axios(`${appUrl}/api/media/8e245d9679d31e12`);
+    const res = await axios(`${appUrl}/api/media/8e245d9679d31e12/1234`);
     expect(res.status).toBe(200);
     expect(res.data).toHaveProperty('_id');
     expect(res.data).toHaveProperty('genres', ['Adventure', 'Drama', 'Sci-Fi'])

--- a/test/e2e/media.spec.ts
+++ b/test/e2e/media.spec.ts
@@ -3,10 +3,10 @@ import MediaMetadataModel from '../../src/models/MediaMetadata';
 import * as mongoose from 'mongoose';
 import axios from 'axios';
 
-import { MongoMemoryServer } from 'mongodb-memory-server';
+import { MongoMemoryServer } from 'mongodb-memory-server-core';
 const mongod = new MongoMemoryServer();
 
-const mediaMetaData = { title: 'Interstellar', genres: ['Adventure', 'Drama', 'Sci-Fi'], osdbHash: '8e245d9679d31e12' };
+const mediaMetaData = { title: 'Interstellar', genres: ['Adventure', 'Drama', 'Sci-Fi'], osdbHash: 'f4245d9379d31e33' };
 const appUrl: string = 'http://localhost:3000'
 
 describe('Media Metadata endpoints', () => {
@@ -25,12 +25,32 @@ describe('Media Metadata endpoints', () => {
   });
 
   it('should return a valid response for existing media record with osdb hash', async() => {
-    const res = await axios(`${appUrl}/api/media/8e245d9679d31e12/1234`);
+    const res = await axios(`${appUrl}/api/media/f4245d9379d31e33/1234`);
     expect(res.status).toBe(200);
     expect(res.data).toHaveProperty('_id');
     expect(res.data).toHaveProperty('genres', ['Adventure', 'Drama', 'Sci-Fi'])
-    expect(res.data).toHaveProperty('osdbHash', '8e245d9679d31e12')
+    expect(res.data).toHaveProperty('osdbHash', 'f4245d9379d31e33')
     expect(res.data).toHaveProperty('title', 'Interstellar');
+  });
+
+  it('should return a valid response for a new osdbhash, then store it', async() => {
+    // using example file from https://trac.opensubtitles.org/projects/opensubtitles/wiki/HashSourceCodes
+    const res = await axios(`${appUrl}/api/media/8e245d9679d31e12/12909756`);
+    expect(res.status).toBe(200);
+    expect(res.data).toHaveProperty('_id');
+    expect(res.data).toHaveProperty('year', '2007');
+    expect(res.data).toHaveProperty('osdbHash', '8e245d9679d31e12')
+    expect(res.data).toHaveProperty('title', 'The Simpsons Movie');
+    expect(res.data).toHaveProperty('imdbID', 'tt0462538');
+
+    // should save to db
+    let doc = await MediaMetadataModel.findOne({osdbHash: res.data.osdbHash});
+
+    expect(doc).toHaveProperty('_id');
+    expect(doc).toHaveProperty('year', '2007');
+    expect(doc).toHaveProperty('osdbHash', '8e245d9679d31e12')
+    expect(doc).toHaveProperty('title', 'The Simpsons Movie');
+    expect(doc).toHaveProperty('imdbID', 'tt0462538');
   });
     
 });

--- a/test/models/MovieMetadata.spec.ts
+++ b/test/models/MovieMetadata.spec.ts
@@ -1,5 +1,5 @@
 import * as  mongoose from 'mongoose';
-import { MongoMemoryServer } from 'mongodb-memory-server-core';
+import { MongoMemoryServer } from 'mongodb-memory-server';
 import MediaMetadataModel from '../../src/models/MediaMetadata';
 const mediaMetaData = { title: 'Interstellar', genres: ['Adventure', 'Drama', 'Sci-Fi'], osdbHash: '8e245d9679d31e12' };
 

--- a/test/models/MovieMetadata.spec.ts
+++ b/test/models/MovieMetadata.spec.ts
@@ -1,5 +1,5 @@
 import * as  mongoose from 'mongoose';
-import { MongoMemoryServer } from 'mongodb-memory-server';
+import { MongoMemoryServer } from 'mongodb-memory-server-core';
 import MediaMetadataModel from '../../src/models/MediaMetadata';
 const mediaMetaData = { title: 'Interstellar', genres: ['Adventure', 'Drama', 'Sci-Fi'], osdbHash: '8e245d9679d31e12' };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3243,7 +3243,7 @@ mkdirp@^0.5.0, mkdirp@^0.5.1:
   dependencies:
     minimist "0.0.8"
 
-mongodb-memory-server-core@^6.0.1:
+mongodb-memory-server-core@6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/mongodb-memory-server-core/-/mongodb-memory-server-core-6.0.1.tgz#24c7062868e358245e44b7a815c8a69e9078bfbd"
   integrity sha512-0StRByXbDLGqjgai2wLfto4oqbQ6++7bbNY2iBc6kKRyXJAMhAtkOhUoaQdcBAL7LvM6SK4rDh7izfKtv21ruw==
@@ -3265,6 +3265,13 @@ mongodb-memory-server-core@^6.0.1:
     uuid "^3.3.3"
   optionalDependencies:
     mongodb "^3.2.7"
+
+mongodb-memory-server@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/mongodb-memory-server/-/mongodb-memory-server-6.0.1.tgz#3bc692353feb2aa754b722f407b70e9bc9bbe3f6"
+  integrity sha512-eD8w0nV2jcp/+WH4rg+uYtA7m7Qfi4TGI5bjOf5fW6mpRNlm9WkU3l9ZDwW/nw9P4IMNp0f7kM616J5xr/a0fw==
+  dependencies:
+    mongodb-memory-server-core "6.0.1"
 
 mongodb@3.3.2:
   version "3.3.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1125,7 +1125,7 @@ cross-spawn@^5.0.1:
     shebang-command "^1.2.0"
     which "^1.2.9"
 
-cross-spawn@^6.0.0, cross-spawn@^6.0.5:
+cross-spawn@^6.0.0:
   version "6.0.5"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"
   integrity sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==
@@ -1135,6 +1135,15 @@ cross-spawn@^6.0.0, cross-spawn@^6.0.5:
     semver "^5.5.0"
     shebang-command "^1.2.0"
     which "^1.2.9"
+
+cross-spawn@^7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.1.tgz#0ab56286e0f7c24e153d04cc2aa027e43a9a5d14"
+  integrity sha512-u7v4o84SwFpD32Z8IIcPZ6z1/ie24O6RU3RbtL5Y316l3KuHVPx9ItBgWQ6VlfAFnRnTtMUrsQ9MUUTuEZjogg==
+  dependencies:
+    path-key "^3.1.0"
+    shebang-command "^2.0.0"
+    which "^2.0.1"
 
 crypto-random-string@^1.0.0:
   version "1.0.0"
@@ -2126,10 +2135,10 @@ http-signature@~1.2.0:
     jsprim "^1.2.2"
     sshpk "^1.7.0"
 
-https-proxy-agent@^2.2.1:
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-2.2.2.tgz#271ea8e90f836ac9f119daccd39c19ff7dfb0793"
-  integrity sha512-c8Ndjc9Bkpfx/vCJueCPy0jlP4ccCCSNDp8xwCZzPjKJUm+B+u9WX2x98Qx4n1PiMNTWo3D7KK5ifNV/yJyRzg==
+https-proxy-agent@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-3.0.0.tgz#0106efa5d63d6d6f3ab87c999fa4877a3fd1ff97"
+  integrity sha512-y4jAxNEihqvBI5F3SaO2rtsjIOnnNA8sEbuiP+UhJZJHeM2NRm6c09ax2tgqme+SgUUvjao2fJXF4h3D6Cb2HQ==
   dependencies:
     agent-base "^4.3.0"
     debug "^3.1.0"
@@ -3234,13 +3243,13 @@ mkdirp@^0.5.0, mkdirp@^0.5.1:
   dependencies:
     minimist "0.0.8"
 
-mongodb-memory-server-core@5.2.8:
-  version "5.2.8"
-  resolved "https://registry.yarnpkg.com/mongodb-memory-server-core/-/mongodb-memory-server-core-5.2.8.tgz#49f5f351a19944c5f3a3798ff4c642a726e7100e"
-  integrity sha512-NAzVektYa4BNrZIEuwGhXXkxd+Wr8IMgbckfGq10NJe55UppqEZdUBCUxAh0z4HCqIrCzD+G+Aj7S2hWgKHCeA==
+mongodb-memory-server-core@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/mongodb-memory-server-core/-/mongodb-memory-server-core-6.0.1.tgz#24c7062868e358245e44b7a815c8a69e9078bfbd"
+  integrity sha512-0StRByXbDLGqjgai2wLfto4oqbQ6++7bbNY2iBc6kKRyXJAMhAtkOhUoaQdcBAL7LvM6SK4rDh7izfKtv21ruw==
   dependencies:
     camelcase "^5.3.1"
-    cross-spawn "^6.0.5"
+    cross-spawn "^7.0.1"
     debug "^4.1.1"
     decompress "^4.2.0"
     dedent "^0.7.0"
@@ -3248,21 +3257,14 @@ mongodb-memory-server-core@5.2.8:
     find-package-json "^1.2.0"
     get-port "^5.0.0"
     getos "^3.1.1"
-    https-proxy-agent "^2.2.1"
+    https-proxy-agent "^3.0.0"
     lockfile "^1.0.4"
     md5-file "^4.0.0"
     mkdirp "^0.5.1"
     tmp "^0.1.0"
-    uuid "^3.2.1"
+    uuid "^3.3.3"
   optionalDependencies:
-    mongodb ">=3.2.7"
-
-mongodb-memory-server@^5.2.8:
-  version "5.2.8"
-  resolved "https://registry.yarnpkg.com/mongodb-memory-server/-/mongodb-memory-server-5.2.8.tgz#1c9e0f3385e9b0f46de73da3d1c2db3934db2cab"
-  integrity sha512-jObfRiBBUpqA73AhSn//Jof5kjFFnyFKpJ1WS183EasyLOBKc4zCRYV85Iht/ccU/3D0OxwQTeLrS3Yy5Z+6NQ==
-  dependencies:
-    mongodb-memory-server-core "5.2.8"
+    mongodb "^3.2.7"
 
 mongodb@3.3.2:
   version "3.3.2"
@@ -3273,7 +3275,7 @@ mongodb@3.3.2:
     require_optional "^1.0.1"
     safe-buffer "^5.1.2"
 
-mongodb@>=3.2.7:
+mongodb@^3.2.7:
   version "3.3.3"
   resolved "https://registry.yarnpkg.com/mongodb/-/mongodb-3.3.3.tgz#509cad2225a1c56c65a331ed73a0d5d4ed5cbe67"
   integrity sha512-MdRnoOjstmnrKJsK8PY0PjP6fyF/SBS4R8coxmhsfEU7tQ46/J6j+aSHF2n4c2/H8B+Hc/Klbfp8vggZfI0mmA==
@@ -3588,9 +3590,9 @@ once@^1.3.0, once@^1.3.1, once@^1.4.0:
   dependencies:
     wrappy "1"
 
-"opensubtitles-api@https://github.com/SubJunk/opensubtitles-api/#RemoteFiles":
+"opensubtitles-api@https://github.com/js-kyle/opensubtitles-api/#RemoteFiles":
   version "5.0.1"
-  resolved "https://github.com/SubJunk/opensubtitles-api/#7ebc087506ed3f1dd0199d9ea8d485eb266456c2"
+  resolved "https://github.com/js-kyle/opensubtitles-api/#f4cfacf1ca868707e180895d98252e1f6fb18148"
   dependencies:
     urijs "^1.19.1"
     xmlrpc "^1.3.2"
@@ -3738,6 +3740,11 @@ path-key@^2.0.0, path-key@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-2.0.1.tgz#411cadb574c5a140d3a4b1910d40d80cc9f40b40"
   integrity sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=
+
+path-key@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/path-key/-/path-key-3.1.0.tgz#99a10d870a803bdd5ee6f0470e58dfcd2f9a54d3"
+  integrity sha512-8cChqz0RP6SHJkMt48FW0A7+qUOn+OsnOsVtzI59tZ8m+5bCSk7hzwET0pulwOM2YMn9J1efb07KB9l9f30SGg==
 
 path-parse@^1.0.6:
   version "1.0.6"
@@ -4272,10 +4279,22 @@ shebang-command@^1.2.0:
   dependencies:
     shebang-regex "^1.0.0"
 
+shebang-command@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-2.0.0.tgz#ccd0af4f8835fbdc265b82461aaf0c36663f34ea"
+  integrity sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==
+  dependencies:
+    shebang-regex "^3.0.0"
+
 shebang-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
   integrity sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=
+
+shebang-regex@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
+  integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
 
 shellwords@^0.1.1:
   version "0.1.1"
@@ -4871,7 +4890,7 @@ utils-merge@1.0.1:
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
   integrity sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=
 
-uuid@^3.2.1, uuid@^3.3.2:
+uuid@^3.3.2, uuid@^3.3.3:
   version "3.3.3"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.3.tgz#4568f0216e78760ee1dbf3a4d2cf53e224112866"
   integrity sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ==
@@ -4956,6 +4975,13 @@ which@^1.2.9, which@^1.3.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
   integrity sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==
+  dependencies:
+    isexe "^2.0.0"
+
+which@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/which/-/which-2.0.1.tgz#f1cf94d07a8e571b6ff006aeb91d0300c47ef0a4"
+  integrity sha512-N7GBZOTswtB9lkQBZA4+zAXrjEIWAUOB93AvzUiudRzRxhUdLURQ7D/gAIMY1gatT/LTbmbcv8SiYazy3eYB7w==
   dependencies:
     isexe "^2.0.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3597,9 +3597,9 @@ once@^1.3.0, once@^1.3.1, once@^1.4.0:
   dependencies:
     wrappy "1"
 
-"opensubtitles-api@https://github.com/js-kyle/opensubtitles-api/#RemoteFiles":
+"opensubtitles-api@https://github.com/js-kyle/opensubtitles-api#RemoteFiles":
   version "5.0.1"
-  resolved "https://github.com/js-kyle/opensubtitles-api/#f4cfacf1ca868707e180895d98252e1f6fb18148"
+  resolved "https://github.com/js-kyle/opensubtitles-api#6943eb6dd53e3569f576a51a8a2719022a17b34e"
   dependencies:
     urijs "^1.19.1"
     xmlrpc "^1.3.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3588,6 +3588,13 @@ once@^1.3.0, once@^1.3.1, once@^1.4.0:
   dependencies:
     wrappy "1"
 
+"opensubtitles-api@https://github.com/SubJunk/opensubtitles-api/#RemoteFiles":
+  version "5.0.1"
+  resolved "https://github.com/SubJunk/opensubtitles-api/#7ebc087506ed3f1dd0199d9ea8d485eb266456c2"
+  dependencies:
+    urijs "^1.19.1"
+    xmlrpc "^1.3.2"
+
 optimist@^0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/optimist/-/optimist-0.6.1.tgz#da3ea74686fa21a19a111c326e90eb15a0196686"
@@ -4180,7 +4187,7 @@ saslprep@^1.0.0:
   dependencies:
     sparse-bitfield "^3.0.3"
 
-sax@^1.2.4:
+sax@1.2.x, sax@^1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
   integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
@@ -4824,6 +4831,11 @@ uri-js@^4.2.2:
   dependencies:
     punycode "^2.1.0"
 
+urijs@^1.19.1:
+  version "1.19.2"
+  resolved "https://registry.yarnpkg.com/urijs/-/urijs-1.19.2.tgz#f9be09f00c4c5134b7cb3cf475c1dd394526265a"
+  integrity sha512-s/UIq9ap4JPZ7H1EB5ULo/aOUbWqfDi7FKzMC2Nz+0Si8GiT1rIEaprt8hy3Vy2Ex2aJPpOQv4P4DuOZ+K1c6w==
+
 urix@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/urix/-/urix-0.1.0.tgz#da937f7a62e21fec1fd18d49b35c2935067a6c72"
@@ -5024,6 +5036,19 @@ xml-name-validator@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-3.0.0.tgz#6ae73e06de4d8c6e47f9fb181f78d648ad457c6a"
   integrity sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==
+
+xmlbuilder@8.2.x:
+  version "8.2.2"
+  resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-8.2.2.tgz#69248673410b4ba42e1a6136551d2922335aa773"
+  integrity sha1-aSSGc0ELS6QuGmE2VR0pIjNap3M=
+
+xmlrpc@^1.3.2:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/xmlrpc/-/xmlrpc-1.3.2.tgz#26b2ea347848d028aac7e7514b5351976de3e83d"
+  integrity sha1-JrLqNHhI0Ciqx+dRS1NRl23j6D0=
+  dependencies:
+    sax "1.2.x"
+    xmlbuilder "8.2.x"
 
 xtend@^4.0.0:
   version "4.0.2"


### PR DESCRIPTION
`/api/media/:osdbhash/:filebytesize` will now query the Open Subtitles service when an existing document for that osdb hash is not found in the connected database instance

The response from Open Subtitles is stored in the database after the first query - so for any particular osdb hash, we will only ever query their api once.

A full e2e test has been added for this, using a test user agent provided by Open Subtitles.

This relies on a minor fixup in my fork of https://github.com/js-kyle/opensubtitles-api/tree/RemoteFiles

I think after this PR is through we need to identify what we need to store, and check the data types are an expected, as the base is there, it just needs specific detail I think