### PR TITLE
basic dependabot config

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,4 @@
+version: 1
+update_configs:
+  - package_manager: "javascript"
+    update_schedule: "weekly"


### PR DESCRIPTION
This config will make it run weekly to check for dependency upgrades, however security issues are 'live' and will make a PR as soon as any fixes become available

https://app.dependabot.com/ needs authorized which I cant do