### PR TITLE
fix(series_metadata): Wrong TV series returned

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,6 +120,7 @@
   "dependencies": {
     "debug": "^4.3.1",
     "episode-parser": "^2.0.0",
+    "escape-string-regexp": "^4.0.0",
     "imdb-api": "^4.4.1",
     "koa": "^2.13.1",
     "koa-bodyparser": "^4.3.0",

--- a/src/interfaces.d.ts
+++ b/src/interfaces.d.ts
@@ -49,3 +49,8 @@ interface GetVideoFilter {
   season?: string;
   title?: string;
 }
+
+interface ExactSearchQuery {
+  title: RegExp;
+  startYear?: string;
+}

--- a/src/models/SeriesMetadata.ts
+++ b/src/models/SeriesMetadata.ts
@@ -1,6 +1,8 @@
 import * as mongoose from 'mongoose';
 import { Schema, Document, Model  } from 'mongoose';
 import * as _ from 'lodash';
+import * as escapeStringRegexp from 'escape-string-regexp';
+import { threadId } from 'worker_threads';
 
 const TEXT_SCORE_MINIMUM = 1;
 
@@ -90,6 +92,13 @@ SeriesMetadataSchema.statics.findSimilarSeries = async function(title: string, s
     bestGuessQuery.startYear = startYear;
   } else {
     sortBy.startYear = 1;
+  }
+
+  const escapedTitle = new RegExp(`^${escapeStringRegexp(title)}$`);
+  const seriesMetadata = await this.findOne({ title: escapedTitle }).lean();
+
+  if (seriesMetadata) {
+    return seriesMetadata;
   }
 
   const bestGuesses = await this.find(bestGuessQuery, { score: { $meta: 'textScore' } })

--- a/src/models/SeriesMetadata.ts
+++ b/src/models/SeriesMetadata.ts
@@ -91,15 +91,21 @@ SeriesMetadataSchema.statics.findSimilarSeries = async function(title: string, s
     sortBy.startYear = 1;
   }
 
-  const bestGuess = await this.find(bestGuessQuery, { score: { $meta: 'textScore' } })
+  const bestGuesses = await this.find(bestGuessQuery, { score: { $meta: 'textScore' } })
     .sort(sortBy)
-    .limit(1)
+    .limit(5)
     .lean();
 
-  if (bestGuess[0] && (bestGuess[0].score < TEXT_SCORE_MINIMUM)) {
+  // returns the first document for an exact title match, which is already ordered by the text search score
+  const hasExactMatch = _.find(bestGuesses, (doc) => doc.title.toLowerCase() === title.toLowerCase());
+  if (hasExactMatch) {
+    return hasExactMatch;
+  }
+
+  if (bestGuesses[0] && (bestGuesses[0].score < TEXT_SCORE_MINIMUM)) {
     return null;
   }
-  return bestGuess[0] || null;
+  return bestGuesses[0] || null;
 };
 
 SeriesMetadataSchema.virtual('imdburl').get(function() {

--- a/src/models/SeriesMetadata.ts
+++ b/src/models/SeriesMetadata.ts
@@ -2,7 +2,6 @@ import * as mongoose from 'mongoose';
 import { Schema, Document, Model  } from 'mongoose';
 import * as _ from 'lodash';
 import * as escapeStringRegexp from 'escape-string-regexp';
-import { threadId } from 'worker_threads';
 
 const TEXT_SCORE_MINIMUM = 1;
 

--- a/src/models/SeriesMetadata.ts
+++ b/src/models/SeriesMetadata.ts
@@ -1,5 +1,6 @@
 import * as mongoose from 'mongoose';
 import { Schema, Document, Model  } from 'mongoose';
+import * as _ from 'lodash';
 
 const TEXT_SCORE_MINIMUM = 1;
 


### PR DESCRIPTION
This was an interesting bug, it is occurring due to how text search works, where exact matches are not necessarily given the highest score.

This stack overflow answer explains the issue really well, but i took a different approach since aggregation framework will be slower to get our result https://stackoverflow.com/questions/31519127/mongodb-search-and-sort-with-number-of-matches-and-exact-match

I have testing this against prod dataset and it returns adventure time correctly