### PR TITLE
feat: subversioning

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -72,6 +72,7 @@ app.use(bodyParser());
 app.use(mediaRouter.routes());
 app.use(indexRouter.routes());
 
+
 export const server = http.createServer(app.callback()).listen(PORT);
 console.log(`UMS API HTTP server is up and running on port ${PORT}`);
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -72,7 +72,6 @@ app.use(bodyParser());
 app.use(mediaRouter.routes());
 app.use(indexRouter.routes());
 
-
 export const server = http.createServer(app.callback()).listen(PORT);
 console.log(`UMS API HTTP server is up and running on port ${PORT}`);
 

--- a/src/helpers/subversioning.ts
+++ b/src/helpers/subversioning.ts
@@ -1,0 +1,8 @@
+export const mediaApiSubversions = {
+  '/osdbhash/:osdbhash/:filebytesize': '1',
+  '/title': '1',
+  '/v2/title': '1',
+  '/seriestitle': '1',
+  '/imdbid': '1',
+  '/video': '1',
+};

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -1,8 +1,13 @@
 import * as Router from 'koa-router';
+import { mediaApiSubversions } from '../helpers/subversioning';
 
 const router = new Router();
 router.get('/', (ctx) => {
   ctx.body = { status: 'OK' };
+});
+
+router.get('/api/subversions', (ctx) => {
+  ctx.body = { '/api/media': mediaApiSubversions };
 });
 
 export default router;

--- a/src/routes/media.ts
+++ b/src/routes/media.ts
@@ -1,29 +1,36 @@
 import * as Router from 'koa-router';
 import * as MediaController from '../controllers/media';
+import { mediaApiSubversions } from '../helpers/subversioning';
 
 const router = new Router({ prefix: '/api/media' });
 
 router.get('/osdbhash/:osdbhash/:filebytesize', async(ctx) => {
+  ctx.set('X-Api-Subversion', mediaApiSubversions['/osdbhash/:osdbhash/:filebytesize']);
   await MediaController.getByOsdbHash(ctx);
 });
 
 router.get('/title', async(ctx) => {
+  ctx.set('X-Api-Subversion', mediaApiSubversions['/title']);
   await MediaController.getBySanitizedTitle(ctx);
 });
 
 router.get('/v2/title', async(ctx) => {
+  ctx.set('X-Api-Subversion', mediaApiSubversions['/v2/title']);
   await MediaController.getBySanitizedTitleV2(ctx);
 });
 
 router.get('/seriestitle', async(ctx) => {
+  ctx.set('X-Api-Subversion', mediaApiSubversions['/seriestitle']);
   await MediaController.getSeriesByTitle(ctx);
 });
 
 router.get('/imdbid', async(ctx) => {
+  ctx.set('X-Api-Subversion', mediaApiSubversions['/imdbid']);
   await MediaController.getByImdbID(ctx);
 });
 
 router.get('/video', async(ctx) => {
+  ctx.set('X-Api-Subversion', mediaApiSubversions['/video']);
   await MediaController.getVideo(ctx);
 });
 

--- a/test/e2e/media-video.spec.ts
+++ b/test/e2e/media-video.spec.ts
@@ -53,6 +53,7 @@ const EPISODE_BAND_OF_BROTHERS = {
 interface UmsApiGotResponse  {
   statusCode: number;
   body: MediaMetadataInterfaceDocument;
+  headers?: object;
 }
 
 describe('get by all', () => {
@@ -76,6 +77,7 @@ describe('get by all', () => {
     it('should return a movie by imdbid, from source APIs then store', async() => {
       const spy = jest.spyOn(apihelper, 'getFromIMDbAPIV2');
       let response = await got(`${appUrl}/api/media/video?imdbID=${MOVIE_INTERSTELLAR.imdbId}`, { responseType: 'json' }) as UmsApiGotResponse;
+      expect(response.headers['X-Api-Subversion']).toBeTruthy();
       expect(response.body.title).toEqual('Interstellar');
       expect(response.body.type).toEqual('movie');
       expect(spy).toHaveBeenCalledTimes(1);

--- a/test/e2e/media-video.spec.ts
+++ b/test/e2e/media-video.spec.ts
@@ -77,7 +77,7 @@ describe('get by all', () => {
     it('should return a movie by imdbid, from source APIs then store', async() => {
       const spy = jest.spyOn(apihelper, 'getFromIMDbAPIV2');
       let response = await got(`${appUrl}/api/media/video?imdbID=${MOVIE_INTERSTELLAR.imdbId}`, { responseType: 'json' }) as UmsApiGotResponse;
-      expect(response.headers['X-Api-Subversion']).toBeTruthy();
+      expect(response.headers['x-api-subversion']).toBeTruthy();
       expect(response.body.title).toEqual('Interstellar');
       expect(response.body.type).toEqual('movie');
       expect(spy).toHaveBeenCalledTimes(1);

--- a/test/e2e/media.spec.ts
+++ b/test/e2e/media.spec.ts
@@ -81,7 +81,7 @@ describe('Media Metadata endpoints', () => {
     it('should return a valid response for existing media record with osdb hash', async() => {
       await MediaMetadataModel.create(interstellarMetaData);
       const res = await got(`${appUrl}/api/media/osdbhash/${interstellarMetaData.osdbHash}/1234`, { responseType: 'json' }) as UmsApiGotResponse;
-      expect(res.headers['X-Api-Subversion']).toBeTruthy();
+      expect(res.headers['x-api-subversion']).toBeTruthy();
       expect(res.statusCode).toBe(200);
       expect(res.body).toHaveProperty('_id');
       expect(res.body).toHaveProperty('genres', interstellarMetaData.genres);

--- a/test/e2e/media.spec.ts
+++ b/test/e2e/media.spec.ts
@@ -12,6 +12,7 @@ const mongod = new MongoMemoryServer();
 interface UmsApiGotResponse  {
   statusCode: number;
   body: MediaMetadataInterfaceDocument;
+  headers?: object;
 }
 
 const aloneEpisodeMetaData = {
@@ -80,6 +81,7 @@ describe('Media Metadata endpoints', () => {
     it('should return a valid response for existing media record with osdb hash', async() => {
       await MediaMetadataModel.create(interstellarMetaData);
       const res = await got(`${appUrl}/api/media/osdbhash/${interstellarMetaData.osdbHash}/1234`, { responseType: 'json' }) as UmsApiGotResponse;
+      expect(res.headers['X-Api-Subversion']).toBeTruthy();
       expect(res.statusCode).toBe(200);
       expect(res.body).toHaveProperty('_id');
       expect(res.body).toHaveProperty('genres', interstellarMetaData.genres);


### PR DESCRIPTION
- Adds a custom http header to identify which subversion of an endpoint is serving a response to a client
- adds an new endpoint `/api/subversions` to return metadata about current endpoints and their subversions

https://github.com/UniversalMediaServer/api/issues/480