### PR TITLE
workaround for default projections not applied to Model.create()

### DIFF
--- a/src/controllers/media.ts
+++ b/src/controllers/media.ts
@@ -530,7 +530,7 @@ export const getVideo = async(ctx: ParameterizedContext): Promise<MediaMetadataI
       combinedResponse.osdbHash = osdbHash;
     }
     const dbMeta = await MediaMetadata.create(combinedResponse);
-    return ctx.body = dbMeta.toJSON();
+    return ctx.body = dbMeta.toObject({ useProjection: true });
   } catch (e) {
     await FailedLookups.updateOne(failedLookupQuery, { $inc: { count: 1 } }, { upsert: true, setDefaultsOnInsert: true }).exec();
     throw new MediaNotFoundError();

--- a/src/controllers/media.ts
+++ b/src/controllers/media.ts
@@ -530,7 +530,7 @@ export const getVideo = async(ctx: ParameterizedContext): Promise<MediaMetadataI
       combinedResponse.osdbHash = osdbHash;
     }
     const dbMeta = await MediaMetadata.create(combinedResponse);
-    return ctx.body = dbMeta;
+    return ctx.body = dbMeta.toJSON();
   } catch (e) {
     await FailedLookups.updateOne(failedLookupQuery, { $inc: { count: 1 } }, { upsert: true, setDefaultsOnInsert: true }).exec();
     throw new MediaNotFoundError();

--- a/test/e2e/media-video.spec.ts
+++ b/test/e2e/media-video.spec.ts
@@ -74,14 +74,13 @@ describe('get by all', () => {
   });
 
   describe('Movies', () => {
-    it.only('should return a movie by imdbid, from source APIs then store', async() => {
+    it('should return a movie by imdbid, from source APIs then store', async() => {
       const spy = jest.spyOn(apihelper, 'getFromIMDbAPIV2');
       let response = await got(`${appUrl}/api/media/video?imdbID=${MOVIE_INTERSTELLAR.imdbId}`, { responseType: 'json' }) as UmsApiGotResponse;
       expect(response.headers['x-api-subversion']).toBeTruthy();
-      console.log(response.body);
       expect(response.body.title).toEqual('Interstellar');
       expect(response.body.type).toEqual('movie');
-      expect(response.body.searchMatches).toBeNull();
+      expect(response.body.searchMatches).toBeUndefined();
       expect(spy).toHaveBeenCalledTimes(1);
       spy.mockReset();
 

--- a/test/e2e/media-video.spec.ts
+++ b/test/e2e/media-video.spec.ts
@@ -80,6 +80,7 @@ describe('get by all', () => {
       expect(response.headers['x-api-subversion']).toBeTruthy();
       expect(response.body.title).toEqual('Interstellar');
       expect(response.body.type).toEqual('movie');
+      expect(response.body.searchMatches).toBeNull();
       expect(spy).toHaveBeenCalledTimes(1);
       spy.mockReset();
 

--- a/test/e2e/media-video.spec.ts
+++ b/test/e2e/media-video.spec.ts
@@ -74,10 +74,11 @@ describe('get by all', () => {
   });
 
   describe('Movies', () => {
-    it('should return a movie by imdbid, from source APIs then store', async() => {
+    it.only('should return a movie by imdbid, from source APIs then store', async() => {
       const spy = jest.spyOn(apihelper, 'getFromIMDbAPIV2');
       let response = await got(`${appUrl}/api/media/video?imdbID=${MOVIE_INTERSTELLAR.imdbId}`, { responseType: 'json' }) as UmsApiGotResponse;
       expect(response.headers['x-api-subversion']).toBeTruthy();
+      console.log(response.body);
       expect(response.body.title).toEqual('Interstellar');
       expect(response.body.type).toEqual('movie');
       expect(response.body.searchMatches).toBeNull();


### PR DESCRIPTION
fixes #524
note that this issue would only have been occurring once per creation of the document

ref https://github.com/Automattic/mongoose/issues/9118
