### PR TITLE
natural import update

### DIFF
--- a/src/services/external-api-helper.ts
+++ b/src/services/external-api-helper.ts
@@ -2,7 +2,7 @@ import { Movie, SearchRequest, TVShow } from '@universalmediaserver/imdb-api';
 import * as _ from 'lodash';
 import * as episodeParser from 'episode-parser';
 import { Episode, EpisodeRequest, ExternalId, SearchMovieRequest, SearchTvRequest, TvExternalIdsResponse } from 'moviedb-promise/dist/request-types';
-import * as natural from 'natural';
+import { JaroWinklerDistance } from 'natural';
 
 import osAPI from './opensubtitles';
 import omdbAPI from './omdb-api';
@@ -97,7 +97,7 @@ export const getFromOMDbAPIV2 = async(imdbId?: string, searchRequest?: SearchReq
       }
 
       // find the best search results utilising the Jaro-Winkler distance metric
-      const searchResultStringDistance = searchResults.results.map(result => natural.JaroWinklerDistance(searchRequest.name, result.title));
+      const searchResultStringDistance = searchResults.results.map(result => JaroWinklerDistance(searchRequest.name, result.title));
       const bestSearchResultKey = _.indexOf(searchResultStringDistance, _.max(searchResultStringDistance));
 
       const searchResult = searchResults.results[bestSearchResultKey] as Movie;


### PR DESCRIPTION
This library is allocating heaps of array objects between heapshots, which could, or could not contribute to the memory leak. Hoping this import change should reduce it, or at least the noise in js heap snapshots

<img width="1546" alt="Screenshot 2023-04-10 at 4 12 25 PM" src="https://user-images.githubusercontent.com/23022619/230824882-9e69ab88-668d-4100-ba2c-5544f33da7cc.png">
