### PR TITLE
Prevent dupes in the searchMatches array

### DIFF
--- a/src/controllers/media.ts
+++ b/src/controllers/media.ts
@@ -20,7 +20,7 @@ import * as externalAPIHelper from '../services/external-api-helper';
 export const addSearchMatchByIMDbID = async(imdbID: string, title: string): Promise<MediaMetadataInterface> => {
   return MediaMetadata.findOneAndUpdate(
     { imdbID },
-    { $push: { searchMatches: title } },
+    { $addToSet: { searchMatches: title } },
     { new: true, lean: true },
   ).exec();
 };

--- a/src/services/external-api-helper.ts
+++ b/src/services/external-api-helper.ts
@@ -23,7 +23,7 @@ import { FlattenMaps, Types } from 'mongoose';
 const addSearchMatchByIMDbID = async(imdbID: string, searchMatch: string) => {
   return SeriesMetadata.findOneAndUpdate(
     { imdbID },
-    { $push: { searchMatches: searchMatch } },
+    { $addToSet: { searchMatches: searchMatch } },
     { new: true, lean: true },
   ).exec();
 };
@@ -93,7 +93,7 @@ export const getSeriesMetadata = async(
     if (existingSeries) {
       const updatedResult = await SeriesMetadata.findOneAndUpdate(
         { imdbID },
-        { $push: { searchMatches: searchMatch } },
+        { $addToSet: { searchMatches: searchMatch } },
         { new: true, lean: true },
       ).exec();
       return updatedResult;
@@ -146,7 +146,7 @@ export const getSeriesMetadata = async(
       if (titleToCache) {
         return await SeriesMetadata.findOneAndUpdate(
           { _id: seriesMetadata._id },
-          { $push: { searchMatches: titleToCache } },
+          { $addToSet: { searchMatches: titleToCache } },
           { new: true, lean: true },
         ).exec();
       }


### PR DESCRIPTION
In some cases it was tens of thousands of items long with most of them identical