### PR TITLE
Attempt to fix very slow queries with compound indexes

### DIFF
--- a/src/models/FailedLookups.ts
+++ b/src/models/FailedLookups.ts
@@ -61,6 +61,10 @@ const FailedLookupsSchema = new Schema({
   timestamps: true,
 });
 
+FailedLookupsSchema.index({ title: 1, language: 1, year: 1 });
+FailedLookupsSchema.index({ title: 1, episode: 1, season: 1 });
+FailedLookupsSchema.index({ title: 1, language: 1, episode: 1, season: 1 });
+
 const FailedLookups = mongoose.model<FailedLookupsInterfaceDocument>('FailedLookups', FailedLookupsSchema);
 
 FailedLookups.on('index', function(err) {

--- a/src/models/MediaMetadata.ts
+++ b/src/models/MediaMetadata.ts
@@ -111,6 +111,8 @@ const MediaMetadataSchema: Schema = new Schema({
   versionKey: false,
 });
 
+MediaMetadataSchema.index({ episode: 1, season: 1, searchMatches: 1 });
+
 MediaMetadataSchema.pre<MediaMetadataInterface>('save', function(next) {
   if (this.title && this.title.startsWith('Episode #')) {
     this.title = undefined;


### PR DESCRIPTION
We can probably remove some non-compound indexes too for fields that are not queried on their own, like episode and season